### PR TITLE
fixed mobile ui a bit

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -42,6 +42,10 @@ body {
 
 }
 
+p {
+  margin-bottom: 0.4em;
+}
+
 #stumbleSection {
   grid-column-start: 2;
   grid-column-end: 7;
@@ -114,11 +118,10 @@ body {
   border: solid black;
   box-shadow: 10px 10px;
 
-  font-size: 60px;
+  font-size: 3.8em;
   font-weight: bold;
 
   background-color: var(--accent);
-
 }
 
 #submissionPanel {
@@ -131,7 +134,7 @@ body {
   border-radius: 25px;
   background-color: var(--ac-light);
 
-  font-size: 60px;
+  font-size: 3.5em;
   font-weight: bold;
 }
 
@@ -149,7 +152,7 @@ body {
   flex-direction: row;
   justify-content: space-around;
   font-size: 18pt;
-  justify-self: flex-end; 
+  justify-self: flex-end;
 }
 
 #historyList {
@@ -196,7 +199,7 @@ body {
 }
 
 .likeIcon {
-  height: 50px;
+  height: 2em;
   cursor: pointer;
 }
 
@@ -218,7 +221,8 @@ body {
   font-size: 30pt;
   font-weight: bolder;
 
-  align-self: center;
+  text-align: center;
+  margin-bottom: 0.5em;
 }
 
 .pulse {
@@ -315,20 +319,47 @@ body {
     grid-row-start: 4;
     grid-row-end: 5;
   }
-  
 }
 
 
 @media screen and (max-height: 750px) {
   #stumbleButton {
-    font-size: 8vh;
+    font-size: 3em;
   }
 
   #submissionInput {
-    font-size: 8vh;
+    font-size: 1em;
   }
 
   #submitButton {
-    font-size: 8vh;
+    font-size: 3em;
+  }
+
+  #aboutSection {
+    border: 1px solid black;
+    margin-left: 15px;
+    margin-right: 15px;
+    padding: 10px;
+  }
+
+  #aboutSectionContent {
+    padding: 10px;
+    overflow: scroll;
+  }
+
+  #adSection {
+    border: 1px solid black;
+    margin-left: 15px;
+    margin-right: 15px;
+    padding: 10px;
+  }
+
+  #adSectionContent {
+    padding: 10px;
+    overflow: scroll;
+  }
+
+  .likeIcon {
+    height: 1.5em;
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -105,7 +105,6 @@ class Stumble extends React.Component {
             id="submitButton"
             className="button"
             onClick={() => {
-
               try {
                 new URL(this.state.submissionUrl);
               } catch (_) {
@@ -133,19 +132,21 @@ class Stumble extends React.Component {
 function About() {
   return (
     <div id="aboutSection">
-      <h1 className="title">StumblingOn</h1>
-      <p className="text">Click STUMBLE get a random webpage. Explore unique independent websites. It's the old, weird,
-        and adventurous feeling of the web. Explore random webpages.</p>
-      <p className="text">Submit a website. Submit YOUR website. Nothing popular, pornographic, or professional. Made
-        something and want to share? You're in exactly the right place. We'd love to have you.</p>
-      <p className="text">You might think StumblingOn is a Stumble Upon alternative or Stumble Upon clone. I agree and
-        hope google returns it as the first result for "Stumble Upon Alternative"</p>
-      <p className="text">Follow development on <a href="https://www.youtube.com/channel/UCqYOAWurt9umvwSrTGXBykw/"
-        target="_blank" rel="noreferrer">YouTube</a></p>
-      <div id="aboutLinks"><a href="https://service.stumblingon.com/metrics" target="_blank"
-        rel="noreferrer">metrics</a> <a href="https://service.stumblingon.com/docs#/"
-          target="_blank" rel="noreferrer">api</a> <a
-            href="https://github.com/inteoryx/StumblingOnUI" target="_blank" rel="noreferrer">github</a></div>
+      <div id="aboutSectionContent">
+        <h1 className="title">StumblingOn</h1>
+        <p className="text">Click STUMBLE get a random webpage. Explore unique independent websites. It's the old, weird,
+          and adventurous feeling of the web. Explore random webpages.</p>
+        <p className="text">Submit a website. Submit YOUR website. Nothing popular, pornographic, or professional. Made
+          something and want to share? You're in exactly the right place. We'd love to have you.</p>
+        <p className="text">You might think StumblingOn is a Stumble Upon alternative or Stumble Upon clone. I agree and
+          hope google returns it as the first result for "Stumble Upon Alternative"</p>
+        <p className="text">Follow development on <a href="https://www.youtube.com/channel/UCqYOAWurt9umvwSrTGXBykw/"
+                                                     target="_blank" rel="noreferrer">YouTube</a></p>
+        <div id="aboutLinks"><a href="https://service.stumblingon.com/metrics" target="_blank"
+                                rel="noreferrer">metrics</a> <a href="https://service.stumblingon.com/docs#/"
+                                                                target="_blank" rel="noreferrer">api</a> <a
+          href="https://github.com/inteoryx/StumblingOnUI" target="_blank" rel="noreferrer">github</a></div>
+      </div>
     </div>
   );
 }
@@ -233,11 +234,13 @@ function Modal(props) {
 function Ad() {
   return (
     <div id="adSection">
-      <h1 className="title">Ad</h1>
-      <p className="text">Psst. Hey kid. Wanna make some money? Like, free money?</p>
-      <p className="text">Join <a href="https://crypto.com/app/9s97gpwtm3" target="_blank"
-        rel="noreferrer">crypto.com</a> with my referral code (9s97gpwtm3). You'll get 25
-        dollars in cryptocurrency if you sign up.</p>
+      <div id="adSectionContent">
+        <h1 className="title">Ad</h1>
+        <p className="text">Psst. Hey kid. Wanna make some money? Like, free money?</p>
+        <p className="text">Join <a href="https://crypto.com/app/9s97gpwtm3" target="_blank"
+                                    rel="noreferrer">crypto.com</a> with my referral code (9s97gpwtm3). You'll get 25
+          dollars in cryptocurrency if you sign up.</p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
played with css to make the site look better on mobile devices.

before it was looking like this on desktop and mobile:

<img width="1678" alt="before" src="https://user-images.githubusercontent.com/7273272/144258539-e5e5b23c-7b8e-436e-9e75-3b80376db984.png">

![before](https://user-images.githubusercontent.com/7273272/144258622-8f13d47a-3b64-458c-a44b-2803af58ed5b.gif)

------

with this pr it looks like this:

<img width="1677" alt="after" src="https://user-images.githubusercontent.com/7273272/144258778-cfbb8695-901b-4a03-a5f2-0c5df41edeff.png">

![after](https://user-images.githubusercontent.com/7273272/144258822-b7571600-2c6a-4e2d-86f5-3e857d9d3059.gif)


------

things that could be improved:
- maybe we can make the `about`, `ad`, and `history` sections in a click-to-expand fashion on mobile.
- reorder `about`, `ad`, and `history` to `ad`, `history` and `about` on mobile.